### PR TITLE
Add fit warning output to kmFit

### DIFF
--- a/R/kmFit.R
+++ b/R/kmFit.R
@@ -57,7 +57,7 @@
 #' # Model with failed genes
 #' kmFit(dat = example.voom,
 #'       patientID = "donorID", libraryID = "libID",
-#'       kin = example.kin, run.lmekin = TRUE,
+#'       kin = example.kin, run.lmekin = TRUE, run.lm = TRUE,
 #'       subset.genes = c("ENSG00000250479","ENSG00000250510","ENSG00000255823"),
 #'       model = "~ virus*asthma + lib.size + norm.factors + median_cv_coverage + donorID+(1|donorID)")
 

--- a/R/kmFit.R
+++ b/R/kmFit.R
@@ -27,11 +27,10 @@
 #'
 #' @examples
 #' # All samples and all genes
-#' # Not run
-#' # kmFit(dat = example.voom,
-#' #       patientID = "donorID", libraryID = "libID",
-#' #       kin = example.kin, run.lmekin = TRUE,
-#' #       model = "~ virus + (1|donorID)", processors = 6)
+#' kmFit(dat = example.voom,
+#'       patientID = "donorID", libraryID = "libID",
+#'       kin = example.kin, run.lmekin = TRUE,
+#'       model = "~ virus + (1|donorID)")
 #'
 #' # Subset samples and genes
 #' kmFit(dat = example.voom,
@@ -54,6 +53,13 @@
 #'       subset.genes = c("ENSG00000250479","ENSG00000250510","ENSG00000255823"),
 #'       model = "~ virus*asthma + (1|donorID)",
 #'       contrast.var=c("virus","virus:asthma"))
+#'
+#' # Model with failed genes
+#' kmFit(dat = example.voom,
+#'       patientID = "donorID", libraryID = "libID",
+#'       kin = example.kin, run.lmekin = TRUE,
+#'       subset.genes = c("ENSG00000250479","ENSG00000250510","ENSG00000255823"),
+#'       model = "~ virus*asthma + lib.size + norm.factors + median_cv_coverage + donorID+(1|donorID)")
 
 kmFit <- function(dat=NULL, kin=NULL, patientID="ptID", libraryID="libID",
                   counts=NULL, meta=NULL, genes=NULL,

--- a/man/kmFit.Rd
+++ b/man/kmFit.Rd
@@ -100,7 +100,7 @@ kmFit(dat = example.voom, kin = example.kin,
 # Model with failed genes
 kmFit(dat = example.voom,
       patientID = "donorID", libraryID = "libID",
-      kin = example.kin, run.lmekin = TRUE,
+      kin = example.kin, run.lmekin = TRUE, run.lm = TRUE,
       subset.genes = c("ENSG00000250479","ENSG00000250510","ENSG00000255823"),
       model = "~ virus*asthma + lib.size + norm.factors + median_cv_coverage + donorID+(1|donorID)")
 }

--- a/man/kmFit.Rd
+++ b/man/kmFit.Rd
@@ -70,11 +70,10 @@ Run lmekin and corresponding lm or lme without kinship of gene expression in RNA
 }
 \examples{
 # All samples and all genes
-# Not run
-# kmFit(dat = example.voom,
-#       patientID = "donorID", libraryID = "libID",
-#       kin = example.kin, run.lmekin = TRUE,
-#       model = "~ virus + (1|donorID)", processors = 6)
+kmFit(dat = example.voom,
+      patientID = "donorID", libraryID = "libID",
+      kin = example.kin, run.lmekin = TRUE,
+      model = "~ virus + (1|donorID)")
 
 # Subset samples and genes
 kmFit(dat = example.voom,
@@ -97,4 +96,11 @@ kmFit(dat = example.voom, kin = example.kin,
       subset.genes = c("ENSG00000250479","ENSG00000250510","ENSG00000255823"),
       model = "~ virus*asthma + (1|donorID)",
       contrast.var=c("virus","virus:asthma"))
+
+# Model with failed genes
+kmFit(dat = example.voom,
+      patientID = "donorID", libraryID = "libID",
+      kin = example.kin, run.lmekin = TRUE,
+      subset.genes = c("ENSG00000250479","ENSG00000250510","ENSG00000255823"),
+      model = "~ virus*asthma + lib.size + norm.factors + median_cv_coverage + donorID+(1|donorID)")
 }

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.0.2",
+    "Version": "4.1.1",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -11,10 +11,8 @@
   "Packages": {
     "renv": {
       "Package": "renv",
-      "Version": "0.13.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "079cb1f03ff972b30401ed05623cbe92"
+      "Version": "0.14.0",
+      "Source": "Repository"
     }
   }
 }

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,13 +2,27 @@
 local({
 
   # the requested version of renv
-  version <- "0.13.2"
+  version <- "0.14.0"
 
   # the project directory
   project <- getwd()
 
+  # allow environment variable to control activation
+  activate <- Sys.getenv("RENV_ACTIVATE_PROJECT")
+  if (!nzchar(activate)) {
+
+    # don't auto-activate when R CMD INSTALL is running
+    if (nzchar(Sys.getenv("R_INSTALL_PKG")))
+      return(FALSE)
+
+  }
+
+  # bail if activation was explicitly disabled
+  if (tolower(activate) %in% c("false", "f", "0"))
+    return(FALSE)
+
   # avoid recursion
-  if (!is.na(Sys.getenv("RENV_R_INITIALIZING", unset = NA)))
+  if (nzchar(Sys.getenv("RENV_R_INITIALIZING")))
     return(invisible(TRUE))
 
   # signal that we're loading renv during R startup


### PR DESCRIPTION
**Describe the purpose of these changes**
Modifies completion message to include total number of failed genes. Saves failed gene names and error messages to `_error` data frames in result list object.

**Tests**
Verify that you have completed the following tests by checking the appropriate box. All tests must pass prior to merging with the main branch.

R packages

- [x] All code contains sufficient commenting
- [x] `check( )` completes with no errors or warnings
- [ ] If the output is changed and is used as example data in another BIGslu package, these changes do not disrupt the other package's workflow. This can be done but running `check( )` within the other package with your changes from this packages loaded by `load_all( )`
