### PR TITLE
summarise_ P-values

### DIFF
--- a/R/kimma_cleaning.R
+++ b/R/kimma_cleaning.R
@@ -21,7 +21,7 @@
 kimma_cleaning <- function(dat=NULL, kin=NULL, patientID="ptID", libraryID="libID",
                            counts=NULL, meta=NULL, genes=NULL,
                            subset.var = NULL, subset.lvl = NULL, subset.genes = NULL){
-  i <- rowname <- NULL
+  i <- rowname <- libID <- NULL
   #If data are NOT a voom EList, create a mock version
   if(is.null(dat)) {
     dat.format <- list()

--- a/R/summarise_lmFit.R
+++ b/R/summarise_lmFit.R
@@ -4,6 +4,7 @@
 #'
 #' @param fdr data.frame output by kimma::extract_lmFit( )
 #' @param fdr.cutoff numeric vector of FDR cutoffs to summarise at
+#' @param p.cutoff numeric vector of P-value cutodds to summarise at. No FDR summary given if p.cutoff is provided
 #' @param FCgroup logical if should separate summary by up/down fold change groups
 #' @param intercept logical if should include intercept variable in summary
 #'
@@ -19,10 +20,11 @@
 #' model_results <- extract_lmFit(design = design, fit = fit)
 #'
 #' # Summarise results
-#' fdr.summary <- summarise_lmFit(fdr = model_results, fdr.cutoff = c(0.05, 0.5), FCgroup = TRUE)
+#' summarise_lmFit(fdr = model_results, fdr.cutoff = c(0.05, 0.5), FCgroup = TRUE)
 #'
 
 summarise_lmFit <- function(fdr, fdr.cutoff = c(0.05,0.1,0.2,0.3,0.4,0.5),
+                            p.cutoff = NULL,
                             FCgroup = FALSE, intercept = FALSE){
   adj.P.Val <- geneName <- group <- n <- variable <- NULL
   if(intercept){
@@ -32,7 +34,10 @@ summarise_lmFit <- function(fdr, fdr.cutoff = c(0.05,0.1,0.2,0.3,0.4,0.5),
       droplevels()
   }
 
-  if(FCgroup){
+  # Use p-values if specified
+  if(!is.null(p.cutoff)){ fdr.cutoff <- p.cutoff }
+
+    if(FCgroup){
     #Blank df for results
     result <- data.frame()
 
@@ -93,6 +98,12 @@ summarise_lmFit <- function(fdr, fdr.cutoff = c(0.05,0.1,0.2,0.3,0.4,0.5),
     dplyr::mutate(variable = forcats::fct_relevel(factor(variable), "total (nonredundant)",
                                                   after=Inf)) %>%
     dplyr::arrange(variable)
+
+  #rename for P-value if specified
+  if(!is.null(p.cutoff)) {
+    result.format <- result.format %>%
+      dplyr::rename_all(~gsub("fdr_","p_",.))
+  }
 
   return(result.format)
 }

--- a/man/summarise_kmFit.Rd
+++ b/man/summarise_kmFit.Rd
@@ -7,6 +7,7 @@
 summarise_kmFit(
   fdr,
   fdr.cutoff = c(0.05, 0.1, 0.2, 0.3, 0.4, 0.5),
+  p.cutoff = NULL,
   contrast = FALSE,
   FCgroup = FALSE,
   intercept = FALSE
@@ -16,6 +17,8 @@ summarise_kmFit(
 \item{fdr}{data.frame output by kimma::kmFit( )}
 
 \item{fdr.cutoff}{numeric vector of FDR cutoffs to summarise at}
+
+\item{p.cutoff}{numeric vector of P-value cutodds to summarise at. No FDR summary given if p.cutoff is provided}
 
 \item{contrast}{logical if should separate summary by pairwise contrasts within variables}
 

--- a/man/summarise_lmFit.Rd
+++ b/man/summarise_lmFit.Rd
@@ -7,6 +7,7 @@
 summarise_lmFit(
   fdr,
   fdr.cutoff = c(0.05, 0.1, 0.2, 0.3, 0.4, 0.5),
+  p.cutoff = NULL,
   FCgroup = FALSE,
   intercept = FALSE
 )
@@ -15,6 +16,8 @@ summarise_lmFit(
 \item{fdr}{data.frame output by kimma::extract_lmFit( )}
 
 \item{fdr.cutoff}{numeric vector of FDR cutoffs to summarise at}
+
+\item{p.cutoff}{numeric vector of P-value cutodds to summarise at. No FDR summary given if p.cutoff is provided}
 
 \item{FCgroup}{logical if should separate summary by up/down fold change groups}
 
@@ -35,6 +38,6 @@ fit <- limma::eBayes(limma::lmFit(example.voom$E, design))
 model_results <- extract_lmFit(design = design, fit = fit)
 
 # Summarise results
-fdr.summary <- summarise_lmFit(fdr = model_results, fdr.cutoff = c(0.05, 0.5), FCgroup = TRUE)
+summarise_lmFit(fdr = model_results, fdr.cutoff = c(0.05, 0.5), FCgroup = TRUE)
 
 }


### PR DESCRIPTION
**Describe the purpose of these changes**
Create `p.cutoff` parameter to allow summaries at P cutoffs instead of FDR. Impacts `summarise_kmFit` and `summarise_lmFit`

**Tests**
Verify that you have completed the following tests by checking the appropriate box. All tests must pass prior to merging with the main branch.

R packages

- [x] All code contains sufficient commenting
- [x] `check( )` completes with no errors or warnings
- [x] If the output is changed and is used as example data in another BIGslu package, these changes do not disrupt the other package's workflow. This can be done but running `check( )` within the other package with your changes from this packages loaded by `load_all( )`
