### PR TITLE
lmekin REML default

### DIFF
--- a/R/kimma_lmekin.R
+++ b/R/kimma_lmekin.R
@@ -20,11 +20,12 @@ kimma_lmekin <- function(model.lme, to.model.gene, gene, kin.subset, use.weights
     if(use.weights){
       fit.kin <- coxme::lmekin(stats::as.formula(model.lme),
                                data=to.model.gene, varlist=as.matrix(kin.subset),
-                               weights=to.model.gene$gene_weight)
+                               weights=to.model.gene$gene_weight,
+                               method="REML")
     } else{
       fit.kin <- coxme::lmekin(stats::as.formula(model.lme),
                                data=to.model.gene, varlist=as.matrix(kin.subset),
-                               weights=NULL)
+                               weights=NULL, method="REML")
     }
 
     #Calculate stats

--- a/man/kmFit.Rd
+++ b/man/kmFit.Rd
@@ -102,7 +102,7 @@ kmFit(dat = example.voom,
       patientID = "donorID", libraryID = "libID",
       run.lme = TRUE, run.contrast = TRUE,
       subset.genes = c("ENSG00000250479","ENSG00000250510","ENSG00000255823"),
-      model = "~ virus+asthma * median_cv_coverage + (1|donorID)",
+      model = "~ virus + asthma * median_cv_coverage + (1|donorID)",
       contrast.var=c("virus","asthma:median_cv_coverage"))
 
 ## With interaction


### PR DESCRIPTION
**Describe the purpose of these changes**
`lmekin` default method changed to REML to match `lmer`.

**Tests**

- [x] All code contains sufficient commenting
- [x] `check( )` completes with no errors or warnings
- [NA] If the output is changed and is used as example data in another BIGslu package, these changes do not disrupt the other package's workflow. This can be done but running `check( )` within the other package with your changes from this packages loaded by `load_all( )`
