### PR TITLE
error: more than 1 row per snp

### DIFF
--- a/R/kmFit_eQTL.R
+++ b/R/kmFit_eQTL.R
@@ -91,12 +91,15 @@ kmFit_eQTL <- function(dat.snp = NULL, within.gene = FALSE,
     stop("Non-numeric genotypes in dat.snp. Please provide only genotypeID, geneID (optional), and numeric 0,1,2 SNP data.")}
 
   #### Data ####
-  #combine genotype and metadata
-  snp.format <- dat.snp %>%
-    tibble::column_to_rownames(genotypeID) %>%
+  num.cols <- dat.snp %>%
     dplyr::select_if(is.numeric) %>%
-    t() %>% as.data.frame() %>%
-    tibble::rownames_to_column(patientID)
+    colnames()
+
+  snp.format <- dat.snp %>%
+    dplyr::select(genotypeID, dplyr::all_of(num.cols)) %>%
+    dplyr::distinct() %>%
+    tidyr::pivot_longer(-dplyr::all_of(genotypeID), names_to = patientID) %>%
+    tidyr::pivot_wider(names_from = genotypeID)
 
   if(!is.null(dat)){
     dat$targets <- dat$targets %>%


### PR DESCRIPTION
**Describe the purpose of these changes**
Correct error with new `kmFit_eQTL` where it fails if a `genotypeID` value is repeated in more than one row. This occurs using `within.gene` since a SNP may be annotated to more than 1 gene, giving it more than 1  row.

**Tests**
R packages

- [x] All code contains sufficient commenting
- [x] `check( )` completes with no errors or warnings
- [x] If the output is changed and is used as example data in another BIGslu package, these changes do not disrupt the other package's workflow. This can be done but running `check( )` within the other package with your changes from this packages loaded by `load_all( )`
