### PR TITLE
Error: custom libraryID not used in kimma_cleaning

### DIFF
--- a/R/kimma_cleaning.R
+++ b/R/kimma_cleaning.R
@@ -25,7 +25,7 @@ kimma_cleaning <- function(dat=NULL, kin=NULL, patientID="ptID", libraryID="libI
                            counts=NULL, meta=NULL, genes=NULL, weights=NULL,
                            subset.var = NULL, subset.lvl = NULL, subset.genes = NULL,
                            model.lm = NULL){
-  i <- rowname <- libID <- NULL
+  i <- rowname <- NULL
   #If data are NOT a voom EList, create a mock version
   if(is.null(dat)) {
     dat.format <- list()
@@ -180,8 +180,8 @@ kimma_cleaning <- function(dat=NULL, kin=NULL, patientID="ptID", libraryID="libI
     if(!is.null(dat.subset$weights)){
       to.model <- to.model %>%
         dplyr::left_join(tidyr::pivot_longer(dat.subset$weights, -rowname,
-                                             names_to = "libID", values_to = "gene_weight"),
-                         by=c("rowname", "libID"))
+                                             names_to = libraryID, values_to = "gene_weight"),
+                         by=c("rowname", libraryID))
     } else{
       to.model <- to.model %>%
         dplyr::mutate(gene_weight = NA)
@@ -245,8 +245,8 @@ kimma_cleaning <- function(dat=NULL, kin=NULL, patientID="ptID", libraryID="libI
     if(!is.null(dat.subset$weights)){
       to.model <- to.model %>%
         dplyr::left_join(tidyr::pivot_longer(dat.subset$weights, -rowname,
-                                             names_to = "libID", values_to = "gene_weight"),
-                         by=c("rowname", "libID"))
+                                             names_to = libraryID, values_to = "gene_weight"),
+                         by=c("rowname", libraryID))
     } else{
       to.model <- to.model %>%
         dplyr::mutate(gene_weight = NA)


### PR DESCRIPTION
**Describe the purpose of these changes**
Correct error in `kimma_cleaning` use of `libraryID` . "libID" is still hardcoded in some sections

**Tests**
R packages

- [x] All code contains sufficient commenting
- [x] `check( )` completes with no errors or warnings
- [x] If the output is changed and is used as example data in another BIGslu package, these changes do not disrupt the other package's workflow. This can be done but running `check( )` within the other package with your changes from this packages loaded by `load_all( )`
