### PR TITLE
Update extract_lmFit to format like kmFit

### DIFF
--- a/R/summarise_lmFit.R
+++ b/R/summarise_lmFit.R
@@ -2,7 +2,7 @@
 #'
 #' Summarise number of significant genes at various FDR cutoffs. Can split by up/down fold change as well.
 #'
-#' @param fdr data.frame output by kimma::extract_lmFit( )
+#' @param fdr data.frame output by kimma::extract_lmFit( ). Specify the model such as fdr$lm
 #' @param fdr.cutoff numeric vector of FDR cutoffs to summarise at
 #' @param p.cutoff numeric vector of P-value cutoffs to summarise at. No FDR summary given if p.cutoff is provided
 #' @param FCgroup logical if should separate summary by up/down fold change groups
@@ -19,7 +19,7 @@
 #' model_results <- extract_lmFit(design = design, fit = fit)
 #'
 #' # Summarise results
-#' summarise_lmFit(fdr = model_results, fdr.cutoff = c(0.05, 0.5), FCgroup = TRUE)
+#' summarise_lmFit(fdr = model_results$lm, fdr.cutoff = c(0.05, 0.5), FCgroup = TRUE)
 #'
 #' # Contrasts model
 #' design <- model.matrix(~ 0 + virus, data = example.voom$targets)
@@ -32,9 +32,11 @@
 #'                                contrast.mat = contrast.mat)
 #'
 #' # Summarise results
-#' summarise_lmFit(fdr = model_results, fdr.cutoff = c(0.05, 0.5), FCgroup = FALSE)
-#' ## No signif results (not run)
-#' # summarise_lmFit(fdr = model_results, fdr.cutoff = 0.0001, FCgroup = FALSE)
+#' summarise_lmFit(fdr = model_results$lm.contrast,
+#'     fdr.cutoff = c(0.05, 0.5), FCgroup = FALSE)
+#' ## No signif results (Not run error)
+#' # summarise_lmFit(fdr = model_results$lm.contrast,
+#' #     fdr.cutoff = 0.0001, FCgroup = FALSE)
 #'
 
 summarise_lmFit <- function(fdr, fdr.cutoff = c(0.05,0.1,0.2,0.3,0.4,0.5),

--- a/man/extract_lmFit.Rd
+++ b/man/extract_lmFit.Rd
@@ -35,7 +35,7 @@ design <- model.matrix(~ virus, data = example.voom$targets)
 fit <- limma::eBayes(limma::lmFit(example.voom$E, design))
 
 ## Get results
-result <- extract_lmFit(design = design, fit = fit)
+fdr <- extract_lmFit(design = design, fit = fit)
 ## Get results and add gene annotations
 fdr <- extract_lmFit(design = design, fit = fit,
                         dat.genes = example.voom$genes, name.genes = "geneName")

--- a/man/summarise_lmFit.Rd
+++ b/man/summarise_lmFit.Rd
@@ -22,7 +22,7 @@ summarize_lmFit(
 )
 }
 \arguments{
-\item{fdr}{data.frame output by kimma::extract_lmFit( )}
+\item{fdr}{data.frame output by kimma::extract_lmFit( ). Specify the model such as fdr$lm}
 
 \item{fdr.cutoff}{numeric vector of FDR cutoffs to summarise at}
 
@@ -47,7 +47,7 @@ fit <- limma::eBayes(limma::lmFit(example.voom$E, design))
 model_results <- extract_lmFit(design = design, fit = fit)
 
 # Summarise results
-summarise_lmFit(fdr = model_results, fdr.cutoff = c(0.05, 0.5), FCgroup = TRUE)
+summarise_lmFit(fdr = model_results$lm, fdr.cutoff = c(0.05, 0.5), FCgroup = TRUE)
 
 # Contrasts model
 design <- model.matrix(~ 0 + virus, data = example.voom$targets)
@@ -60,8 +60,10 @@ model_results <- extract_lmFit(design = design, fit = fit,
                                contrast.mat = contrast.mat)
 
 # Summarise results
-summarise_lmFit(fdr = model_results, fdr.cutoff = c(0.05, 0.5), FCgroup = FALSE)
-## No signif results (not run)
-# summarise_lmFit(fdr = model_results, fdr.cutoff = 0.0001, FCgroup = FALSE)
+summarise_lmFit(fdr = model_results$lm.contrast,
+    fdr.cutoff = c(0.05, 0.5), FCgroup = FALSE)
+## No signif results (Not run error)
+# summarise_lmFit(fdr = model_results$lm.contrast,
+#     fdr.cutoff = 0.0001, FCgroup = FALSE)
 
 }


### PR DESCRIPTION
**Describe the purpose of these changes**
extract_lmFit now outputs a list like kmFit, including lm, lm.contrast, and/or lm.fit

**Tests**

R packages

- [x] All code contains sufficient commenting
- [x] `check( )` completes with no errors or warnings
- [x] If the output is changed and is used as example data in another BIGslu package, these changes do not disrupt the other package's workflow. This can be done but running `check( )` within the other package with your changes from this packages loaded by `load_all( )`
